### PR TITLE
5장 웹 어댑터 구현

### DIFF
--- a/src/main/kotlin/backendsquid/buckpal/account/adapter/web/AccountController.kt
+++ b/src/main/kotlin/backendsquid/buckpal/account/adapter/web/AccountController.kt
@@ -2,8 +2,6 @@ package backendsquid.buckpal.account.adapter.web
 
 import backendsquid.buckpal.account.application.port.`in`.SendMoneyCommand
 import backendsquid.buckpal.account.application.port.`in`.SendMoneyUseCase
-import backendsquid.buckpal.account.domain.Account.*
-import backendsquid.buckpal.account.domain.Money
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -25,9 +23,9 @@ class AccountController(
         @PathVariable("amount") @Positive amount: Long,
     ): Boolean {
         val command = SendMoneyCommand(
-            sourceAccountId = AccountId(sourceAccountId),
-            targetAccountId = AccountId(targetAccountId),
-            money = Money.of(amount),
+            sourceAccountId = sourceAccountId,
+            targetAccountId = targetAccountId,
+            money = amount,
         )
 
         return sendMoneyUseCase.sendMoney(command = command)
@@ -38,9 +36,9 @@ class AccountController(
         @RequestBody @Valid sendMoneyResource: SendMoneyResource
     ): Boolean {
         val command = SendMoneyCommand(
-            sourceAccountId = AccountId(sendMoneyResource.sourceAccountId),
-            targetAccountId = AccountId(sendMoneyResource.targetAccountId),
-            money = Money.of(sendMoneyResource.amount),
+            sourceAccountId = sendMoneyResource.sourceAccountId,
+            targetAccountId = sendMoneyResource.targetAccountId,
+            money = sendMoneyResource.amount,
         )
 
         return sendMoneyUseCase.sendMoney(command = command)

--- a/src/main/kotlin/backendsquid/buckpal/account/adapter/web/AccountController.kt
+++ b/src/main/kotlin/backendsquid/buckpal/account/adapter/web/AccountController.kt
@@ -1,0 +1,48 @@
+package backendsquid.buckpal.account.adapter.web
+
+import backendsquid.buckpal.account.application.port.`in`.SendMoneyCommand
+import backendsquid.buckpal.account.application.port.`in`.SendMoneyUseCase
+import backendsquid.buckpal.account.domain.Account.*
+import backendsquid.buckpal.account.domain.Money
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+import javax.validation.Valid
+import javax.validation.constraints.Positive
+
+@RestController
+@Validated
+class AccountController(
+    private val sendMoneyUseCase: SendMoneyUseCase,
+) {
+
+    @PostMapping("/accounts/send/{sourceAccountId}/{targetAccountId}/{amount}")
+    fun sendMoney(
+        @PathVariable("sourceAccountId") @Positive sourceAccountId: Long,
+        @PathVariable("targetAccountId") @Positive targetAccountId: Long,
+        @PathVariable("amount") @Positive amount: Long,
+    ): Boolean {
+        val command = SendMoneyCommand(
+            sourceAccountId = AccountId(sourceAccountId),
+            targetAccountId = AccountId(targetAccountId),
+            money = Money.of(amount),
+        )
+
+        return sendMoneyUseCase.sendMoney(command = command)
+    }
+
+    @PostMapping("/accounts/send")
+    fun sendMoneyByBody(
+        @RequestBody @Valid sendMoneyResource: SendMoneyResource
+    ): Boolean {
+        val command = SendMoneyCommand(
+            sourceAccountId = AccountId(sendMoneyResource.sourceAccountId),
+            targetAccountId = AccountId(sendMoneyResource.targetAccountId),
+            money = Money.of(sendMoneyResource.amount),
+        )
+
+        return sendMoneyUseCase.sendMoney(command = command)
+    }
+}

--- a/src/main/kotlin/backendsquid/buckpal/account/adapter/web/DoNothingSendMoneyUseCase.kt
+++ b/src/main/kotlin/backendsquid/buckpal/account/adapter/web/DoNothingSendMoneyUseCase.kt
@@ -1,0 +1,12 @@
+package backendsquid.buckpal.account.adapter.web
+
+import backendsquid.buckpal.account.application.port.`in`.SendMoneyCommand
+import backendsquid.buckpal.account.application.port.`in`.SendMoneyUseCase
+import org.springframework.stereotype.Service
+
+@Service
+class DoNothingSendMoneyUseCase: SendMoneyUseCase {
+    override fun sendMoney(command: SendMoneyCommand): Boolean {
+        return true
+    }
+}

--- a/src/main/kotlin/backendsquid/buckpal/account/adapter/web/DoNothingSendMoneyUseCase.kt
+++ b/src/main/kotlin/backendsquid/buckpal/account/adapter/web/DoNothingSendMoneyUseCase.kt
@@ -6,7 +6,5 @@ import org.springframework.stereotype.Service
 
 @Service
 class DoNothingSendMoneyUseCase: SendMoneyUseCase {
-    override fun sendMoney(command: SendMoneyCommand): Boolean {
-        return true
-    }
+    override fun sendMoney(command: SendMoneyCommand): Boolean = true
 }

--- a/src/main/kotlin/backendsquid/buckpal/account/adapter/web/SendMoneyResource.kt
+++ b/src/main/kotlin/backendsquid/buckpal/account/adapter/web/SendMoneyResource.kt
@@ -1,0 +1,12 @@
+package backendsquid.buckpal.account.adapter.web
+
+import javax.validation.constraints.Positive
+
+data class SendMoneyResource(
+    @field:Positive
+    val sourceAccountId: Long,
+    @field:Positive
+    val targetAccountId: Long,
+    @field:Positive
+    val amount: Long,
+)

--- a/src/main/kotlin/backendsquid/buckpal/account/application/port/in/SendMoneyCommand.kt
+++ b/src/main/kotlin/backendsquid/buckpal/account/application/port/in/SendMoneyCommand.kt
@@ -12,6 +12,7 @@ data class SendMoneyCommand(
     val targetAccountId: Account.AccountId,
     val money: Money,
 ): SelfValidating<SendMoneyCommand>() {
+    constructor(sourceAccountId: Long, targetAccountId: Long, money: Long) : this(Account.AccountId(sourceAccountId), Account.AccountId(targetAccountId), Money.of(money))
 
     init {
         if (!money.isPositive()) {


### PR DESCRIPTION
- 웹 어댑터의 책임
- HTTP 요청을 자바 객체로 매핑
- 권한 검사
- 입력 유효성 검증
- 입력을 유스케이스의 입력 모델로 매핑
- 유스케이스 호출
- 유스케이스의 출력을 HTTP로 매핑
- HTTP 응답을 반환

- 컨트롤러 나누기
- 너무 적은 것보다는 많은 것이 낫다.
- 유스케이스를 최대한 반영해서 짓는게 좋다.