### PR TITLE
노을 - 6장 영속성 어댑터 구현하기

### DIFF
--- a/src/main/kotlin/backendsquid/buckpal/account/adapter/out/persistence/AccountJpaEntity.kt
+++ b/src/main/kotlin/backendsquid/buckpal/account/adapter/out/persistence/AccountJpaEntity.kt
@@ -1,0 +1,14 @@
+package backendsquid.buckpal.account.adapter.out.persistence
+
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.Id
+import javax.persistence.Table
+
+@Entity
+@Table(name = "account")
+class AccountJpaEntity(
+    @Id
+    @GeneratedValue
+    var id: Long?
+)

--- a/src/main/kotlin/backendsquid/buckpal/account/adapter/out/persistence/AccountMapper.kt
+++ b/src/main/kotlin/backendsquid/buckpal/account/adapter/out/persistence/AccountMapper.kt
@@ -19,9 +19,9 @@ class AccountMapper {
             Money.of(withdrawalBalance)
         )
         return Account.withId(
-            Account.AccountId(account.id!!),
-            baselineBalance,
-            mapToActivityWindow(activities)
+            accountId = Account.AccountId(account.id!!),
+            baselineBalance = baselineBalance,
+            activityWindow = mapToActivityWindow(activities)
         )
     }
 
@@ -30,26 +30,26 @@ class AccountMapper {
         for (activity in activities) {
             mappedActivities.add(
                 Activity(
-                    Activity.ActivityId(activity.id!!),
-                    Account.AccountId(activity.ownerAccountId),
-                    Account.AccountId(activity.sourceAccountId),
-                    Account.AccountId(activity.targetAccountId),
-                    activity.timestamp,
-                    Money.of(activity.amount)
+                    id = Activity.ActivityId(activity.id!!),
+                    ownerAccountId = Account.AccountId(activity.ownerAccountId),
+                    sourceAccountId = Account.AccountId(activity.sourceAccountId),
+                    targetAccountId = Account.AccountId(activity.targetAccountId),
+                    timestamp = activity.timestamp,
+                    money = Money.of(activity.amount)
                 )
             )
         }
         return ActivityWindow(mappedActivities)
     }
 
-    fun mapToJpaEntity(activity: Activity): ActivityJpaEntity {
-        return ActivityJpaEntity(
-            activity.id?.value,
-            activity.timestamp,
-            activity.ownerAccountId.value,
-            activity.sourceAccountId.value,
-            activity.targetAccountId.value,
-            activity.money.amount.longValueExact()
+    fun mapToJpaEntity(activity: Activity): ActivityJpaEntity =
+        ActivityJpaEntity(
+            id = activity.id?.value,
+            timestamp = activity.timestamp,
+            ownerAccountId = activity.ownerAccountId.value,
+            sourceAccountId = activity.sourceAccountId.value,
+            targetAccountId = activity.targetAccountId.value,
+            amount = activity.money.amount.longValueExact()
         )
-    }
+
 }

--- a/src/main/kotlin/backendsquid/buckpal/account/adapter/out/persistence/AccountMapper.kt
+++ b/src/main/kotlin/backendsquid/buckpal/account/adapter/out/persistence/AccountMapper.kt
@@ -1,0 +1,55 @@
+package backendsquid.buckpal.account.adapter.out.persistence
+
+import backendsquid.buckpal.account.domain.Account
+import backendsquid.buckpal.account.domain.Activity
+import backendsquid.buckpal.account.domain.ActivityWindow
+import backendsquid.buckpal.account.domain.Money
+import org.springframework.stereotype.Component
+
+@Component
+class AccountMapper {
+    fun mapToDomainEntity(
+        account: AccountJpaEntity,
+        activities: List<ActivityJpaEntity>,
+        withdrawalBalance: Long,
+        depositBalance: Long
+    ): Account? {
+        val baselineBalance: Money = Money.subtract(
+            Money.of(depositBalance),
+            Money.of(withdrawalBalance)
+        )
+        return Account.withId(
+            Account.AccountId(account.id!!),
+            baselineBalance,
+            mapToActivityWindow(activities)
+        )
+    }
+
+    fun mapToActivityWindow(activities: List<ActivityJpaEntity>): ActivityWindow {
+        val mappedActivities: MutableList<Activity> = ArrayList()
+        for (activity in activities) {
+            mappedActivities.add(
+                Activity(
+                    Activity.ActivityId(activity.id!!),
+                    Account.AccountId(activity.ownerAccountId),
+                    Account.AccountId(activity.sourceAccountId),
+                    Account.AccountId(activity.targetAccountId),
+                    activity.timestamp,
+                    Money.of(activity.amount)
+                )
+            )
+        }
+        return ActivityWindow(mappedActivities)
+    }
+
+    fun mapToJpaEntity(activity: Activity): ActivityJpaEntity {
+        return ActivityJpaEntity(
+            activity.id?.value,
+            activity.timestamp,
+            activity.ownerAccountId.value,
+            activity.sourceAccountId.value,
+            activity.targetAccountId.value,
+            activity.money.amount.longValueExact()
+        )
+    }
+}

--- a/src/main/kotlin/backendsquid/buckpal/account/adapter/out/persistence/AccountPersistenceAdapter.kt
+++ b/src/main/kotlin/backendsquid/buckpal/account/adapter/out/persistence/AccountPersistenceAdapter.kt
@@ -43,10 +43,10 @@ class AccountPersistenceAdapter(
         )
 
         return accountMapper.mapToDomainEntity(
-            account,
-            activities,
-            withdrawalBalance,
-            depositBalance
+            account = account,
+            activities = activities,
+            withdrawalBalance = withdrawalBalance,
+            depositBalance = depositBalance
         )!!
 
     }

--- a/src/main/kotlin/backendsquid/buckpal/account/adapter/out/persistence/AccountPersistenceAdapter.kt
+++ b/src/main/kotlin/backendsquid/buckpal/account/adapter/out/persistence/AccountPersistenceAdapter.kt
@@ -1,0 +1,60 @@
+package backendsquid.buckpal.account.adapter.out.persistence
+
+import backendsquid.buckpal.account.application.port.out.LoadAccountPort
+import backendsquid.buckpal.account.application.port.out.UpdateAccountStatePort
+import backendsquid.buckpal.account.domain.Account
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+import javax.persistence.EntityNotFoundException
+
+@Component
+class AccountPersistenceAdapter(
+    private val accountRepository: SpringDataAccountRepository,
+    private val activityRepository: ActivityRepository,
+    private val accountMapper: AccountMapper
+) : LoadAccountPort, UpdateAccountStatePort {
+    override fun loadAccount(
+        accountId: Account.AccountId,
+        baseLineDate: LocalDateTime
+    ): Account {
+
+        val account = accountRepository.findByIdOrNull(accountId.value) ?: throw EntityNotFoundException()
+
+        val activities = activityRepository.findByOwnerSince(
+            ownerAccountId = accountId.value,
+            since = baseLineDate
+        )
+
+        val withdrawalBalance = orZero(
+            activityRepository
+                .getWithdrawalBalanceUntil(
+                    accountId = accountId.value,
+                    until = baseLineDate
+                )
+        )
+
+        val depositBalance = orZero(
+            activityRepository
+                .getDepositBalanceUntil(
+                    accountId = accountId.value,
+                    until = baseLineDate
+                )
+        )
+
+        return accountMapper.mapToDomainEntity(
+            account,
+            activities,
+            withdrawalBalance,
+            depositBalance
+        )!!
+
+    }
+
+    override fun updateActivities(account: Account) {
+        val activities = account.activityWindow.getActivities()
+        activities.forEach { it.id ?: activityRepository.save(accountMapper.mapToJpaEntity(it)) }
+    }
+
+    fun orZero(value: Long?): Long = value ?: 0L;
+}

--- a/src/main/kotlin/backendsquid/buckpal/account/adapter/out/persistence/ActivityJpaEntity.kt
+++ b/src/main/kotlin/backendsquid/buckpal/account/adapter/out/persistence/ActivityJpaEntity.kt
@@ -1,0 +1,26 @@
+package backendsquid.buckpal.account.adapter.out.persistence
+
+import java.time.LocalDateTime
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.Id
+import javax.persistence.Table
+
+@Entity
+@Table(name = "activity")
+class ActivityJpaEntity(
+    @Id
+    @GeneratedValue
+    var id: Long?,
+    @Column
+    var timestamp: LocalDateTime,
+    @Column
+    var ownerAccountId: Long,
+    @Column
+    var sourceAccountId: Long,
+    @Column
+    var targetAccountId: Long,
+    @Column
+    var amount: Long
+)

--- a/src/main/kotlin/backendsquid/buckpal/account/adapter/out/persistence/ActivityRepository.kt
+++ b/src/main/kotlin/backendsquid/buckpal/account/adapter/out/persistence/ActivityRepository.kt
@@ -1,0 +1,47 @@
+package backendsquid.buckpal.account.adapter.out.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.LocalDateTime
+
+interface ActivityRepository : JpaRepository<ActivityJpaEntity, Long> {
+    @Query(
+        """
+        select a from ActivityJpaEntity a
+        where a.ownerAccountId = :ownerAccountId
+        and a.timestamp >= :since
+    """
+    )
+    fun findByOwnerSince(
+        @Param("ownerAccountId") ownerAccountId: Long,
+        @Param("since") since: LocalDateTime
+    ): List<ActivityJpaEntity>
+
+    @Query(
+        """
+        select sum(a.amount) from ActivityJpaEntity a 
+        where a.targetAccountId = :accountId 
+        and a.ownerAccountId = :accountId 
+        and a.timestamp < :until
+    """
+    )
+    fun getDepositBalanceUntil(
+        @Param("accountId") accountId: Long,
+        @Param("until") until: LocalDateTime
+    ): Long
+
+    @Query(
+        """
+        select sum(a.amount) from ActivityJpaEntity a 
+        where a.sourceAccountId = :accountId 
+        and a.ownerAccountId = :accountId 
+        and a.timestamp < :until
+    """
+    )
+    fun getWithdrawalBalanceUntil(
+        @Param("accountId") accountId: Long,
+        @Param("until") until: LocalDateTime
+    ): Long
+
+}

--- a/src/main/kotlin/backendsquid/buckpal/account/adapter/out/persistence/ActivityRepository.kt
+++ b/src/main/kotlin/backendsquid/buckpal/account/adapter/out/persistence/ActivityRepository.kt
@@ -29,7 +29,7 @@ interface ActivityRepository : JpaRepository<ActivityJpaEntity, Long> {
     fun getDepositBalanceUntil(
         @Param("accountId") accountId: Long,
         @Param("until") until: LocalDateTime
-    ): Long
+    ): Long?
 
     @Query(
         """
@@ -42,6 +42,6 @@ interface ActivityRepository : JpaRepository<ActivityJpaEntity, Long> {
     fun getWithdrawalBalanceUntil(
         @Param("accountId") accountId: Long,
         @Param("until") until: LocalDateTime
-    ): Long
+    ): Long?
 
 }

--- a/src/main/kotlin/backendsquid/buckpal/account/adapter/out/persistence/SpringDataAccountRepository.kt
+++ b/src/main/kotlin/backendsquid/buckpal/account/adapter/out/persistence/SpringDataAccountRepository.kt
@@ -1,0 +1,6 @@
+package backendsquid.buckpal.account.adapter.out.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface SpringDataAccountRepository : JpaRepository<AccountJpaEntity, Long> {
+}

--- a/src/main/kotlin/backendsquid/buckpal/account/domain/Account.kt
+++ b/src/main/kotlin/backendsquid/buckpal/account/domain/Account.kt
@@ -47,6 +47,15 @@ class Account(
     }
 
     data class AccountId(
-        private val value: Long,
+        val value: Long,
     )
+
+    companion object {
+        fun withId(accountId: AccountId, baselineBalance: Money, activityWindow: ActivityWindow): Account? =
+            Account(
+                id = accountId,
+                baselineBalance = baselineBalance,
+                activityWindow = activityWindow
+            )
+    }
 }

--- a/src/main/kotlin/backendsquid/buckpal/account/domain/Activity.kt
+++ b/src/main/kotlin/backendsquid/buckpal/account/domain/Activity.kt
@@ -12,6 +12,6 @@ data class Activity(
     val money: Money,
 ) {
     data class ActivityId(
-        private val value: Long,
+        val value: Long,
     )
 }

--- a/src/main/kotlin/backendsquid/buckpal/account/domain/Money.kt
+++ b/src/main/kotlin/backendsquid/buckpal/account/domain/Money.kt
@@ -3,7 +3,7 @@ package backendsquid.buckpal.account.domain
 import java.math.BigInteger
 
 data class Money(
-    private val amount: BigInteger
+    val amount: BigInteger
 ): Comparable<Money> {
     companion object {
         val ZERO: Money = Money.of(value = 0)


### PR DESCRIPTION

의존성 역전 
- 애플리케이션 서비스에서는 영속성 어댑터를 사용하기 위해 간접 계층인 포트 인터페이스 호출

인터페이스 분리 원칙
- 각 서비스는 실제로 필요한 메서드만 의존한다.
- 포트의 이름이 포트의 역할을 명확하게 표현한다.